### PR TITLE
Add 'pass' to fix IndentationError in detector.py

### DIFF
--- a/examples/detector.py
+++ b/examples/detector.py
@@ -6,6 +6,7 @@ from dsio.anomaly_detectors import AnomalyMixin
 
 class Greater_Than_Max_Rolling(BaseEstimator, AnomalyMixin):
     def __init__(self, ):
+        pass
 
     def detect(self, x):
         score = self.score(x)


### PR DESCRIPTION
flake8 testing of https://github.com/MentatInnovations/datastream.io

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/detector.py:10:7: E999 IndentationError: expected an indented block
    def detect(self, x):
      ^
1     E999 IndentationError: expected an indented block
```