### PR TITLE
develop input stream from kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,6 @@ You can use dsio with your own hand coded anomaly detectors. These should inheri
 Naturally we encourage people to use `dsio` in combination with `sklearn`: we have no wish to reinvent the wheel! However, `sklearn` currently supports regression, classification and clustering interfaces, but not anomaly detection as a standalone category. We are trying to correct that by the introduction of the `AnomalyMixin`: an interface for anomaly detection which follows `sklearn` design patterns. When you import an `sklearn` object you can therefore simply define or override certain methods to make it compatible with `dsio`. We have provided an example for you here:
 
     ./datamstream.io/examples/lof_anomaly_detector.py
+
+### Read data stream from Kafka (optional)
+It is possible to read a stream of data from Kafka adding the parameter `--kafka-uri` with the list of the bootstrap_servers delimited by `;`. The analysis will be done on a window of `--kafka-window-size` items from the input stream. The input parameter will represent input topic. The parameter `--auto_offset_reset` can be set to latest (default) to read only new messages or to earliest to read a topic from the beginning.

--- a/dsio/dashboard/bokeh.py
+++ b/dsio/dashboard/bokeh.py
@@ -71,7 +71,7 @@ def generate_dashboard(sensors, title, cols=3, port=5001, update_queue=None):
 
     io_loop = tornado.ioloop.IOLoop.current()
 
-    if io_loop._running: # Assume we're in a Jupyter notebook
+    if hasattr(io_loop,'_running'): # Assume we're in a Jupyter notebook
         output_notebook()
         show(app)
     else: # Otherwise start the bokeh server in a thread and open browser

--- a/dsio/helpers.py
+++ b/dsio/helpers.py
@@ -31,6 +31,12 @@ def parse_arguments():
                         default="http://localhost:5601/app/kibana")
     parser.add_argument("--bokeh-port", help="Bokeh server port", default="5001")
     parser.add_argument("--es-index", help="Elasticsearch index name")
+    parser.add_argument("--kafka-uri",help="Kafka broker uri",
+                        default=None)
+    parser.add_argument("--kafka-window-size",help="messages to wait for batch analysis",
+                        default=100)
+    parser.add_argument("--auto_offset_reset",help="kafka offset strategy: earliest or latest",
+                        default="latest")
     parser.add_argument("--entry-type", help="Entry type name",
                         default="measurement")
     parser.add_argument("-v", "--verbose", help="Increase output verbosity",

--- a/examples/kafka-procuder.py
+++ b/examples/kafka-procuder.py
@@ -1,0 +1,30 @@
+from kafka import KafkaProducer
+from kafka.errors import KafkaError
+import json
+
+producer = KafkaProducer(bootstrap_servers=['localhost:9092'],
+                         value_serializer=lambda m: json.dumps(m).encode('ascii'))
+
+messages = [
+    {"timestamp":1522513435, "speed": 30},
+    {"timestamp":1522513535, "speed": 32},
+    {"timestamp":1522513635, "speed": 31},
+    {"timestamp":1522513735, "speed": 29},
+    {"timestamp":1522513835, "speed": 32},
+    {"timestamp":1522513935, "speed": 30},
+    {"timestamp":1522514415, "speed": 600},
+    {"timestamp":1522514425, "speed": 30},
+    {"timestamp":1522514435, "speed": 31},
+    {"timestamp":1522514455, "speed": 29},
+]
+
+for m in messages:
+    try:
+        print('sending {}'.format(m))
+        future=producer.send('json-topic', m)
+        record_metadata = future.get(timeout=10)
+    except KafkaError:
+        # Decide what to do if produce request failed...
+        log.exception()
+        print('error')
+        pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scipy
 pandas
 kibana-dashboard-api
 scikit-learn
+kafka-python


### PR DESCRIPTION
I have developed an optional kafka input source for getting the timeseries.
This option will be enabled if the parameter --kafka-uri is filled with the list of kafka brokers (delimited by ;). In this case the inuput parameter will represent the input topic. The messages are assumed to be valid json encoded as ascii string. The analysis will be performed on batch of --kafka-window-size. Last but not least with the parameter --auto_offset_reset it is possibile to specify the source will read only the new messages or the source is interested of reading also the old messages belonging to the input topic.
 